### PR TITLE
add problem discussion template

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/problem.yml
+++ b/.github/DISCUSSION_TEMPLATE/problem.yml
@@ -1,0 +1,29 @@
+title: "🧩 Problem: "
+labels: []
+body:
+  - type: textarea
+    id: definition
+    attributes:
+      label: Define it
+      description: Can you describe this problem?
+    validations:
+      required: true
+  - type: textarea
+    id: explanation
+    attributes:
+      label: Exemplify it?
+      description: Can you provide examples of where you've observed this problem?
+    validations:
+      required: true
+  - type: textarea
+    id: potential-causes
+    attributes:
+      label: Explain it
+      description: Can you explain why this problem is happening?
+    validations:
+      required: true
+  - type: textarea
+    id: possible-strategies
+    attributes:
+      label: 🧭 Suggest strategies
+      description: Can you identify any potential strategies for approaching this problem?


### PR DESCRIPTION
A lot of my thinking at the moment is fuzzy and it would help me if I can capture some of the major problems/challenges we face on the Programme board. I'm going to do the same thing on the curriculum repo too.

Having the problems clearly captured following ongoing conversations helps me to write clearer milestones and issues etc.